### PR TITLE
Update Ruby to 3.4.9 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:3.4.8
+FROM ruby:3.4.9
 
-LABEL version="3.4.8"
+LABEL version="3.4.9"
 LABEL maintainer="Ain Tohvri <ain.tohvri@samwise-media.com>"
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Google Cloud capable Docker image for Ruby.
 
 ## Features
 
-- Ruby 3.4.8
+- Ruby 3.4.9
 - Node.js v22
 - gcloud
 - Bundler


### PR DESCRIPTION
Update to the latest Ruby [3.4.9](https://www.ruby-lang.org/en/news/2026/03/11/ruby-3-4-9-released/) version